### PR TITLE
Feat(fe)/category menu api

### DIFF
--- a/apps/be/docs/docs.go
+++ b/apps/be/docs/docs.go
@@ -131,9 +131,12 @@ const docTemplate = `{
                 "summary": "카테고리 목록 조회",
                 "responses": {
                     "200": {
-                        "description": "카테고리 이름 배열",
+                        "description": "카테고리 리스트",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCategoryResponseDTO"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.GetCategoryResponseDTO"
+                            }
                         }
                     },
                     "401": {
@@ -352,7 +355,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/menus/sync": {
+        "/menus/": {
             "post": {
                 "description": "여러 메뉴에 대해 생성/수정/삭제 동기화를 처리합니다.",
                 "consumes": [
@@ -404,6 +407,103 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "인증 실패",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/menus/board/{categoryID}": {
+            "get": {
+                "description": "카테고리 ID로 메뉴, 이미지, 태그를 함께 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "menu"
+                ],
+                "summary": "메뉴판 조회",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "카테고리 ID",
+                        "name": "category_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.GetMenuBoardResponseDTO"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/menus/{menuID}": {
+            "get": {
+                "description": "storeID와 menuID로 메뉴 상세 정보를 조회합니다. (Preview, Details, Tags, Images 포함)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "menu"
+                ],
+                "summary": "메뉴 상세 조회",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "메뉴 ID",
+                        "name": "menuId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.GetDescriptionResponseDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "잘못된 요청 (menuId 없음 또는 invalid)",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "인증 실패",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "서버 에러",
                         "schema": {
                             "$ref": "#/definitions/dto.ErrorResponse"
                         }
@@ -463,14 +563,82 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "category": {
+                    "type": "string",
+                    "example": "음료"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "dto.GetDescriptionResponseDTO": {
+            "type": "object",
+            "properties": {
+                "details": {
+                    "type": "string"
+                },
+                "images": {
                     "type": "array",
                     "items": {
                         "type": "string"
-                    },
-                    "example": [
-                        "[\"음료\"",
-                        " \"디저트\"]"
-                    ]
+                    }
+                },
+                "preview": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.GetMenuBoardResponseDTO": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "category_id": {
+                    "type": "integer"
+                },
+                "details": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "image_urls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "menu": {
+                    "type": "string"
+                },
+                "order": {
+                    "type": "string"
+                },
+                "preview": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "store_id": {
+                    "type": "integer"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -490,13 +658,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "order": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "price": {
                     "type": "integer"
                 },
-                "soldOut": {
-                    "type": "boolean"
+                "status": {
+                    "type": "string"
                 },
                 "storeId": {
                     "type": "integer"

--- a/apps/be/docs/swagger.json
+++ b/apps/be/docs/swagger.json
@@ -125,9 +125,12 @@
                 "summary": "카테고리 목록 조회",
                 "responses": {
                     "200": {
-                        "description": "카테고리 이름 배열",
+                        "description": "카테고리 리스트",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCategoryResponseDTO"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.GetCategoryResponseDTO"
+                            }
                         }
                     },
                     "401": {
@@ -346,7 +349,7 @@
                 }
             }
         },
-        "/menus/sync": {
+        "/menus/": {
             "post": {
                 "description": "여러 메뉴에 대해 생성/수정/삭제 동기화를 처리합니다.",
                 "consumes": [
@@ -398,6 +401,103 @@
                     },
                     "401": {
                         "description": "인증 실패",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/menus/board/{categoryID}": {
+            "get": {
+                "description": "카테고리 ID로 메뉴, 이미지, 태그를 함께 조회합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "menu"
+                ],
+                "summary": "메뉴판 조회",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "카테고리 ID",
+                        "name": "category_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.GetMenuBoardResponseDTO"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/menus/{menuID}": {
+            "get": {
+                "description": "storeID와 menuID로 메뉴 상세 정보를 조회합니다. (Preview, Details, Tags, Images 포함)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "menu"
+                ],
+                "summary": "메뉴 상세 조회",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "메뉴 ID",
+                        "name": "menuId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.GetDescriptionResponseDTO"
+                        }
+                    },
+                    "400": {
+                        "description": "잘못된 요청 (menuId 없음 또는 invalid)",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "인증 실패",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "서버 에러",
                         "schema": {
                             "$ref": "#/definitions/dto.ErrorResponse"
                         }
@@ -457,14 +557,82 @@
             "type": "object",
             "properties": {
                 "category": {
+                    "type": "string",
+                    "example": "음료"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "dto.GetDescriptionResponseDTO": {
+            "type": "object",
+            "properties": {
+                "details": {
+                    "type": "string"
+                },
+                "images": {
                     "type": "array",
                     "items": {
                         "type": "string"
-                    },
-                    "example": [
-                        "[\"음료\"",
-                        " \"디저트\"]"
-                    ]
+                    }
+                },
+                "preview": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "dto.GetMenuBoardResponseDTO": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "category_id": {
+                    "type": "integer"
+                },
+                "details": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "image_urls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "menu": {
+                    "type": "string"
+                },
+                "order": {
+                    "type": "string"
+                },
+                "preview": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "store_id": {
+                    "type": "integer"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -484,13 +652,13 @@
                     "type": "string"
                 },
                 "order": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "price": {
                     "type": "integer"
                 },
-                "soldOut": {
-                    "type": "boolean"
+                "status": {
+                    "type": "string"
                 },
                 "storeId": {
                     "type": "integer"

--- a/apps/be/docs/swagger.yaml
+++ b/apps/be/docs/swagger.yaml
@@ -34,9 +34,54 @@ definitions:
   dto.GetCategoryResponseDTO:
     properties:
       category:
-        example:
-        - '["음료"'
-        - ' "디저트"]'
+        example: 음료
+        type: string
+      id:
+        example: 1
+        type: integer
+    type: object
+  dto.GetDescriptionResponseDTO:
+    properties:
+      details:
+        type: string
+      images:
+        items:
+          type: string
+        type: array
+      preview:
+        type: string
+      tags:
+        items:
+          type: string
+        type: array
+    type: object
+  dto.GetMenuBoardResponseDTO:
+    properties:
+      category:
+        type: string
+      category_id:
+        type: integer
+      details:
+        type: string
+      id:
+        type: integer
+      image_urls:
+        items:
+          type: string
+        type: array
+      menu:
+        type: string
+      order:
+        type: string
+      preview:
+        type: string
+      price:
+        type: integer
+      status:
+        type: string
+      store_id:
+        type: integer
+      tags:
         items:
           type: string
         type: array
@@ -52,11 +97,11 @@ definitions:
       menu:
         type: string
       order:
-        type: integer
+        type: string
       price:
         type: integer
-      soldOut:
-        type: boolean
+      status:
+        type: string
       storeId:
         type: integer
     type: object
@@ -199,9 +244,11 @@ paths:
       - application/json
       responses:
         "200":
-          description: 카테고리 이름 배열
+          description: 카테고리 리스트
           schema:
-            $ref: '#/definitions/dto.GetCategoryResponseDTO'
+            items:
+              $ref: '#/definitions/dto.GetCategoryResponseDTO'
+            type: array
         "401":
           description: 인증 실패
           schema:
@@ -346,7 +393,7 @@ paths:
       summary: 메뉴 목록 조회
       tags:
       - menu
-  /menus/sync:
+  /menus/:
     post:
       consumes:
       - application/json
@@ -383,6 +430,71 @@ paths:
           schema:
             $ref: '#/definitions/dto.ErrorResponse'
       summary: 메뉴 동기화
+      tags:
+      - menu
+  /menus/{menuID}:
+    get:
+      description: storeID와 menuID로 메뉴 상세 정보를 조회합니다. (Preview, Details, Tags, Images
+        포함)
+      parameters:
+      - description: 메뉴 ID
+        in: path
+        name: menuId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.GetDescriptionResponseDTO'
+        "400":
+          description: 잘못된 요청 (menuId 없음 또는 invalid)
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "401":
+          description: 인증 실패
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: 서버 에러
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: 메뉴 상세 조회
+      tags:
+      - menu
+  /menus/board/{categoryID}:
+    get:
+      description: 카테고리 ID로 메뉴, 이미지, 태그를 함께 조회합니다.
+      parameters:
+      - description: 카테고리 ID
+        in: path
+        name: category_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/dto.GetMenuBoardResponseDTO'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: 메뉴판 조회
       tags:
       - menu
 swagger: "2.0"

--- a/apps/be/internal/category/controller/category.controller.go
+++ b/apps/be/internal/category/controller/category.controller.go
@@ -60,7 +60,13 @@ func (c *CategoryController) CreateCategory(ctx *fiber.Ctx) error {
 // @Description  storeID에 해당하는 카테고리 이름 목록을 조회합니다.
 // @Tags         category
 // @Produce      json
-// @Success      200 {object} dto.GetCategoryResponseDTO "카테고리 이름 배열"
+// @Success 	 200 {array} dto.GetCategoryResponseDTO "카테고리 리스트"
+// @Description 응답 예시:
+// @Description [
+// @Description   {"id": 1, "category": "음료"},
+// @Description   {"id": 2, "category": "디저트"}
+// @Description ]
+
 // @Failure      401 {object} errorDto.ErrorResponse "인증 실패"
 // @Failure      500 {object} errorDto.ErrorResponse "조회 실패"
 // @Router       /categories [get]
@@ -75,14 +81,15 @@ func (c *CategoryController) GetCategories(ctx *fiber.Ctx) error {
 		return ctx.Status(500).JSON(errorDto.ErrorResponse{Error: "failed to fetch categories"})
 	}
 
-	var names []string
+	var result []dto.GetCategoryResponseDTO
 	for _, cat := range categories {
-		names = append(names, cat.Category)
+		result = append(result, dto.GetCategoryResponseDTO{
+			ID:       cat.ID,
+			Category: cat.Category,
+		})
 	}
 
-	return ctx.JSON(dto.GetCategoryResponseDTO{
-		Category: names,
-	})
+	return ctx.Status(fiber.StatusOK).JSON(result)
 }
 
 // UpdateCategory godoc

--- a/apps/be/internal/category/controller/category.controller.go
+++ b/apps/be/internal/category/controller/category.controller.go
@@ -60,13 +60,7 @@ func (c *CategoryController) CreateCategory(ctx *fiber.Ctx) error {
 // @Description  storeID에 해당하는 카테고리 이름 목록을 조회합니다.
 // @Tags         category
 // @Produce      json
-// @Success 	 200 {array} dto.GetCategoryResponseDTO "카테고리 리스트"
-// @Description 응답 예시:
-// @Description [
-// @Description   {"id": 1, "category": "음료"},
-// @Description   {"id": 2, "category": "디저트"}
-// @Description ]
-
+// @Success      200 {array} dto.GetCategoryResponseDTO "카테고리 리스트"
 // @Failure      401 {object} errorDto.ErrorResponse "인증 실패"
 // @Failure      500 {object} errorDto.ErrorResponse "조회 실패"
 // @Router       /categories [get]

--- a/apps/be/internal/category/dto/get_category_response.dto.go
+++ b/apps/be/internal/category/dto/get_category_response.dto.go
@@ -1,5 +1,6 @@
 package dto
 
 type GetCategoryResponseDTO struct {
-	Category []string `json:"category" example:"[\"음료\", \"디저트\"]"`
+	ID		uint `json:"id" example:"1"`
+	Category string `json:"category" example:"음료"`
 }

--- a/apps/be/internal/category/repository/category.repository.go
+++ b/apps/be/internal/category/repository/category.repository.go
@@ -27,7 +27,7 @@ func (r *categoryRepository) Save(category *models.Category) error {
 
 func (r *categoryRepository) FindByStoreID(storeID uint) ([]models.Category, error) {
 	var categories []models.Category
-	if err := r.db.Where("store_id = ?", storeID).Find(&categories).Error; err != nil {
+	if err := r.db.Where("store_id = ?", storeID).Order("`order` ASC").Find(&categories).Error; err != nil {
 		return nil, err
 	}
 	return categories, nil
@@ -35,8 +35,7 @@ func (r *categoryRepository) FindByStoreID(storeID uint) ([]models.Category, err
 
 func (r *categoryRepository) FindByIDAndStoreID(id uint, storeID uint) (models.Category, error) {
 	var category models.Category
-	err := r.db.Where("id = ? AND store_id = ?", id, storeID).
-		First(&category).Error
+	err := r.db.Where("id = ? AND store_id = ?", id, storeID).First(&category).Error
 	return category, err
 }
 
@@ -45,6 +44,5 @@ func (r *categoryRepository) Update(category models.Category) error {
 }
 
 func (r *categoryRepository) Delete(categoryID uint, storeID uint) error {
-	return r.db.Where("id = ? AND store_id = ?", categoryID, storeID).
-		Delete(&models.Category{}).Error
+	return r.db.Where("id = ? AND store_id = ?", categoryID, storeID).Delete(&models.Category{}).Error
 }

--- a/apps/be/internal/menu/controller/menu.controller.go
+++ b/apps/be/internal/menu/controller/menu.controller.go
@@ -7,6 +7,7 @@ import (
 	"be/internal/menu/dto"
 	errorDto "be/internal/common/dto"
 	"be/internal/middleware"
+	"strconv"
 )
 
 type MenuController struct {
@@ -51,7 +52,7 @@ func (c *MenuController) GetMenus(ctx *fiber.Ctx) error {
 // @Failure      207 {object} map[string]interface{} "일부 실패"
 // @Failure      401 {object} errorDto.ErrorResponse "인증 실패"
 // @Failure      400 {object} errorDto.ErrorResponse "요청 바디 오류"
-// @Router       /menus/sync [post]
+// @Router       /menus/ [post]
 func (c *MenuController) SyncMenus(ctx *fiber.Ctx) error {
 	storeID, err := middleware.ExtractStoreID(ctx)
 	if err != nil {
@@ -74,4 +75,73 @@ func (c *MenuController) SyncMenus(ctx *fiber.Ctx) error {
 	return ctx.JSON(fiber.Map{
 		"message": "sync completed successfully",
 	})
+}
+
+// GetMenuBoard godoc
+// @Summary      메뉴판 조회
+// @Description  카테고리 ID로 메뉴, 이미지, 태그를 함께 조회합니다.
+// @Tags         menu
+// @Produce      json
+// @Param        category_id path int true "카테고리 ID"
+// @Success      200 {array} dto.GetMenuBoardResponseDTO
+// @Failure      400 {object} errorDto.ErrorResponse
+// @Failure      401 {object} errorDto.ErrorResponse
+// @Failure      500 {object} errorDto.ErrorResponse
+// @Router       /menus/board/{categoryID} [get]
+func (c *MenuController) GetMenuBoard(ctx *fiber.Ctx) error {
+	storeID, err := middleware.ExtractStoreID(ctx)
+	if err != nil {
+		return ctx.Status(401).JSON(errorDto.ErrorResponse{Error: "unauthorized"})
+	}
+
+	categoryParam := ctx.Params("categoryID")
+	if categoryParam == "" {
+		return ctx.Status(400).JSON(errorDto.ErrorResponse{Error: "categoryID is required"})
+	}
+
+	categoryID, err := strconv.Atoi(categoryParam)
+	if err != nil {
+		return ctx.Status(400).JSON(errorDto.ErrorResponse{Error: "invalid category_id"})
+	}
+
+	menus, err := c.service.GetMenuBoard(storeID, uint(categoryID))
+	if err != nil {
+		return ctx.Status(500).JSON(errorDto.ErrorResponse{Error: "failed to fetch menu board"})
+	}
+
+	return ctx.JSON(menus)
+}
+
+// GetDescription godoc
+// @Summary      메뉴 상세 조회
+// @Description  storeID와 menuID로 메뉴 상세 정보를 조회합니다. (Preview, Details, Tags, Images 포함)
+// @Tags         menu
+// @Produce      json
+// @Param        menuId path int true "메뉴 ID"
+// @Success      200 {object} dto.GetDescriptionResponseDTO
+// @Failure      400 {object} errorDto.ErrorResponse "잘못된 요청 (menuId 없음 또는 invalid)"
+// @Failure      401 {object} errorDto.ErrorResponse "인증 실패"
+// @Failure      500 {object} errorDto.ErrorResponse "서버 에러"
+// @Router       /menus/{menuID} [get]
+func (c *MenuController) GetDescription(ctx *fiber.Ctx) error {
+	storeID, err := middleware.ExtractStoreID(ctx)
+	if err != nil {
+		return ctx.Status(401).JSON(errorDto.ErrorResponse{Error : "unauthorized"})
+	}
+	menuParam := ctx.Params("menuID")
+	if menuParam == "" {
+		return ctx.Status(400).JSON(errorDto.ErrorResponse{Error: "menuId is required"})
+	}
+
+	menuID, err := strconv.Atoi(menuParam)
+	if err != nil {
+		return ctx.Status(400).JSON(errorDto.ErrorResponse{Error: "invalid menu_id"})
+	}
+
+	description, err := c.service.GetDescription(storeID, uint(menuID))
+	if err != nil {
+		return ctx.Status(500).JSON(errorDto.ErrorResponse{Error: "failed to fetch description"})
+	}
+
+	return ctx.JSON(description)
 }

--- a/apps/be/internal/menu/dto/get_description_response.dto.go
+++ b/apps/be/internal/menu/dto/get_description_response.dto.go
@@ -1,0 +1,8 @@
+package dto
+
+type GetDescriptionResponseDTO struct {
+	Preview string   `json:"preview"`
+	Details string   `json:"details"`
+	Tags    []string `json:"tags"`
+	Images  []string `json:"images"`
+}

--- a/apps/be/internal/menu/dto/get_menu_board_response.dto.go
+++ b/apps/be/internal/menu/dto/get_menu_board_response.dto.go
@@ -1,0 +1,16 @@
+package dto
+
+type GetMenuBoardResponseDTO struct {
+	ID         uint     `json:"id"`
+	Menu       string   `json:"menu"`
+	Price      int      `json:"price"`
+	Status     string   `json:"status"`
+	Order      string   `json:"order"`
+	StoreID    uint     `json:"store_id"`
+	CategoryID uint     `json:"category_id"`
+	Category   string   `json:"category"`
+	ImageURLs  []string `json:"image_urls"`
+	Tags       []string `json:"tags"`
+	Preview    string   `json:"preview"`
+	Details    string   `json:"details"`
+}

--- a/apps/be/internal/menu/dto/get_menu_response.dto.go
+++ b/apps/be/internal/menu/dto/get_menu_response.dto.go
@@ -4,8 +4,8 @@ type GetMenuResponseDTO struct {
 	ID         uint   `json:"id"`
 	Menu       string `json:"menu"`
 	Price      int    `json:"price"`
-	SoldOut    bool   `json:"soldOut"`
-	Order      int    `json:"order"`
+	Status     string `json:"status"`
+	Order      string `json:"order"`
 	StoreID    uint   `json:"storeId"`
 	CategoryID *uint  `json:"categoryId,omitempty"`
 	Category   string `json:"category"`

--- a/apps/be/internal/menu/repository/menu.repository.go
+++ b/apps/be/internal/menu/repository/menu.repository.go
@@ -1,8 +1,8 @@
 package repository
 
 import (
-	"gorm.io/gorm"
 	"be/internal/models"
+	"gorm.io/gorm"
 )
 
 type MenuRepository interface {
@@ -10,6 +10,10 @@ type MenuRepository interface {
 	CreateMenu(menu *models.Menu) error
 	UpdateMenu(menu *models.Menu) error
 	DeleteMenu(menuID uint, storeID uint) error
+	FindImages(storeID, menuID uint) ([]models.Image, error)
+	FindTags(storeID, menuID uint) ([]models.Tag, error)
+	FindMenuBoard(storeID, categoryID uint) ([]models.Menu, error)
+	FindDescription(storeID, menuID uint) (models.Menu, error)
 }
 
 type menuRepository struct {
@@ -20,31 +24,61 @@ func NewMenuRepository(db *gorm.DB) MenuRepository {
 	return &menuRepository{db: db}
 }
 
-// FindByStoreID: StoreID로 메뉴 리스트 조회 (카테고리 포함)
 func (r *menuRepository) FindByStoreID(storeID uint) ([]models.Menu, error) {
 	var menus []models.Menu
 	err := r.db.
 		Preload("Category").
-		Select("id", "menu", "price", "sold_out", "`order`", "store_id", "category_id").
+		Select("id", "menu", "price", "status", "`order`", "store_id", "category_id").
 		Where("store_id = ?", storeID).
 		Find(&menus).Error
 
 	return menus, err
 }
 
-// Create: 메뉴 생성
 func (r *menuRepository) CreateMenu(menu *models.Menu) error {
 	return r.db.Create(menu).Error
 }
 
-// Update: 메뉴 정보 갱신
 func (r *menuRepository) UpdateMenu(menu *models.Menu) error {
 	return r.db.Save(menu).Error
 }
 
-// Delete: 메뉴 삭제 (storeID 조건 포함)
 func (r *menuRepository) DeleteMenu(storeID uint, menuID uint) error {
 	return r.db.
 		Where("id = ? AND store_id = ?", menuID, storeID).
 		Delete(&models.Menu{}).Error
+}
+
+func (r *menuRepository) FindImages(storeID, menuID uint) ([]models.Image, error) {
+	var images []models.Image
+	result := r.db.Where("store_id = ? AND menu_id = ?", storeID, menuID).
+		Order("`order` ASC").
+		Find(&images)
+	return images, result.Error
+}
+
+func (r *menuRepository) FindTags(storeID, menuID uint) ([]models.Tag, error) {
+	var tags []models.Tag
+	result := r.db.Where("store_id = ? AND menu_id = ?", storeID, menuID).
+		Find(&tags)
+	return tags, result.Error
+}
+
+func (r *menuRepository) FindMenuBoard(storeID, categoryID uint) ([]models.Menu, error) {
+	var menus []models.Menu
+	result := r.db.Preload("Category").
+		Where("store_id = ? AND category_id = ?", storeID, categoryID).
+		Order("`order` ASC").
+		Find(&menus)
+	return menus, result.Error
+}
+
+func (r *menuRepository) FindDescription(storeID, menuID uint) (models.Menu, error) {
+	var menu models.Menu
+	err := r.db.
+		Preload("Category").
+		Where("store_id = ? AND id = ?", storeID, menuID).
+		First(&menu).Error
+
+	return menu, err
 }

--- a/apps/be/internal/menu/route/menu.route.go
+++ b/apps/be/internal/menu/route/menu.route.go
@@ -20,6 +20,8 @@ func InitMenuRoutes(router fiber.Router, db *gorm.DB) {
 	// ✅ 여기에 API들 등록
 	group.Get("/", ctrl.GetMenus)        // GET /api/menus
 	group.Post("/", ctrl.SyncMenus)      // POST /api/menus/
+	group.Get("/board/:categoryID", ctrl.GetMenuBoard)
+	group.Get("/:menuID", ctrl.GetDescription)
 //	group.Post("/", ctrl.CreateMenus)      // POST /api/menus
 //	group.Patch("/:menuId", ctrl.UpdateMenus)    // PUT /api/menus/:id
 //	group.Delete("/:menuId", ctrl.DeleteMenus) // DELETE /api/menus/:id

--- a/apps/be/internal/menu/service/menu.service.go
+++ b/apps/be/internal/menu/service/menu.service.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 	"be/internal/menu/dto"
 	"be/internal/menu/repository"
+	"be/internal/models"
 	"be/internal/utils"
 )
 
 type MenuService interface {
 	GetAllByStoreID(storeID uint) ([]dto.GetMenuResponseDTO, error)
 	SyncMenus(storeID uint, syncDatas []dto.SyncMenuRequestDTO) ([]dto.SyncMenuErrorDTO, error)
+	GetImageURLs(storeID, menuID uint) ([]string, error)
+	GetTags(storeID, menuID uint) ([]string, error)
+	GetMenuBoard(storeID, categoryID uint) ([]dto.GetMenuBoardResponseDTO, error)
+	GetDescription(storeID, menuID uint) (dto.GetDescriptionResponseDTO, error)
 }
 
 type menuService struct {
@@ -32,7 +37,7 @@ func (s *menuService) GetAllByStoreID(storeID uint) ([]dto.GetMenuResponseDTO, e
 			ID:         menu.ID,
 			Menu:       menu.Menu,
 			Price:      menu.Price,
-			SoldOut:    menu.SoldOut,
+			Status:     menu.Status,
 			Order:      menu.Order,
 			StoreID:    menu.StoreID,
 			CategoryID: menu.CategoryID,
@@ -41,7 +46,6 @@ func (s *menuService) GetAllByStoreID(storeID uint) ([]dto.GetMenuResponseDTO, e
 	}
 	return result, nil
 }
-
 
 func (s *menuService) SyncMenus(storeID uint, syncDatas []dto.SyncMenuRequestDTO) ([]dto.SyncMenuErrorDTO, error) {
 	var errs []dto.SyncMenuErrorDTO
@@ -84,4 +88,84 @@ func (s *menuService) SyncMenus(storeID uint, syncDatas []dto.SyncMenuRequestDTO
 		return errs, fmt.Errorf("one or more sync errors occurred")
 	}
 	return nil, nil
+}
+
+func (s *menuService) GetImageURLs(storeID, menuID uint) ([]string, error) {
+	images, err := s.repo.FindImages(storeID, menuID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Image : %v", err)
+	}
+
+	var urls []string
+	for _, img := range images {
+		urls = append(urls, img.ImageURL)
+	}
+	return urls, nil
+}
+
+func (s *menuService) GetTags(storeID, menuID uint) ([]string, error) {
+	tags, err := s.repo.FindTags(storeID, menuID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Tags: %v", err)
+	}
+
+	var result []string
+	for _, tag := range tags {
+		result = append(result, tag.Tag)
+	}
+	return result, nil
+}
+
+func (s *menuService) GetMenuBoard(storeID, categoryID uint) ([]dto.GetMenuBoardResponseDTO, error) {
+	menus, err := s.repo.FindMenuBoard(storeID, categoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []dto.GetMenuBoardResponseDTO
+	for _, menu := range menus {
+		result = append(result, s.buildMenuResponse(menu, storeID))
+	}
+
+	return result, nil
+}
+
+func (s *menuService) GetDescription(storeID, menuID uint) (dto.GetDescriptionResponseDTO, error) {
+	description, err := s.repo.FindDescription(storeID, menuID)
+	if err != nil {
+		return dto.GetDescriptionResponseDTO{}, err
+	}
+
+	menuResponse := s.buildMenuResponse(description, storeID)
+
+	return dto.GetDescriptionResponseDTO{
+		Preview: description.Preview,
+		Details: description.Details,
+		Tags: menuResponse.Tags,
+		Images: menuResponse.ImageURLs,
+	}, nil
+}
+
+func (s *menuService) buildMenuResponse(menu models.Menu, storeID uint) dto.GetMenuBoardResponseDTO {
+	imageURLs, _ := s.GetImageURLs(storeID, menu.ID)
+	tags, _ := s.GetTags(storeID, menu.ID)
+	var categoryIDVal uint
+	if menu.CategoryID != nil {
+		categoryIDVal = *menu.CategoryID
+	}
+
+	return dto.GetMenuBoardResponseDTO{
+		ID:         menu.ID,
+		Menu:       menu.Menu,
+		Price:      menu.Price,
+		Status:     menu.Status,
+		Order:      menu.Order,
+		StoreID:    menu.StoreID,
+		CategoryID: categoryIDVal,
+		Category:   menu.Category.Category,
+		ImageURLs:  imageURLs,
+		Tags:       tags,
+		Details:	menu.Details,
+		Preview: menu.Preview,
+	}
 }

--- a/apps/be/internal/models/category.go
+++ b/apps/be/internal/models/category.go
@@ -5,6 +5,6 @@ type Category struct {
     Category    string
     StoreID uint
     Store   Store `gorm:"foreignKey:StoreID" json:"-"`
-
+    Order string
     Menus   []Menu
 }

--- a/apps/be/internal/models/image.go
+++ b/apps/be/internal/models/image.go
@@ -7,5 +7,5 @@ type Image struct {
     Menu     Menu
     StoreID  uint
     Store    Store
+    Order    string
 }
-

--- a/apps/be/internal/models/menu.go
+++ b/apps/be/internal/models/menu.go
@@ -13,8 +13,8 @@ type Menu struct {
     StoreID uint
     Store   Store
 
-    SoldOut bool
-    Order   int
+    Status string
+    Order   string
 
     Images         []Image
     RecommandMenus []RecommandMenu

--- a/apps/be/internal/models/menu.go
+++ b/apps/be/internal/models/menu.go
@@ -1,17 +1,20 @@
 package models
 
 type Menu struct {
-    ID          uint   `gorm:"primaryKey"`
-    Menu        string
-    Preview     string
-    Details     string
-    Price       int
-    CategoryID *uint `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
-    Category    Category
-    StoreID     uint
-    Store       Store
-    SoldOut     bool
-    Order       int
+    ID       uint   `gorm:"primaryKey"`
+    Menu     string
+    Preview  string
+    Details  string
+    Price    int
+
+    CategoryID *uint
+    Category   Category `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+
+    StoreID uint
+    Store   Store
+
+    SoldOut bool
+    Order   int
 
     Images         []Image
     RecommandMenus []RecommandMenu

--- a/apps/be/internal/models/tag.go
+++ b/apps/be/internal/models/tag.go
@@ -5,4 +5,6 @@ type Tag struct {
 	Tag			 string
 	MenuID  uint
     Menu    Menu
+	StoreID  uint
+    Store    Store
 }

--- a/apps/be/internal/utils/menu_mapper.go
+++ b/apps/be/internal/utils/menu_mapper.go
@@ -16,11 +16,11 @@ func MapToMenu(storeID uint, data map[string]any) *models.Menu {
 	if v, ok := data["price"].(float64); ok {
 		menu.Price = int(v)
 	}
-	if v, ok := data["soldOut"].(bool); ok {
-		menu.SoldOut = v
+	if v, ok := data["status"].(string); ok {
+		menu.Status = v
 	}
-	if v, ok := data["order"].(float64); ok {
-		menu.Order = int(v)
+	if v, ok := data["order"].(string); ok {
+		menu.Order = v
 	}
 	if v, ok := data["categoryId"].(float64); ok {
 		categoryID := uint(v)

--- a/apps/be/main.go
+++ b/apps/be/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	app.Use(cors.New(cors.Config{
 		AllowOrigins:     "http://localhost:3000", // 프론트 도메인
-		AllowMethods:     "GET,POST,PUT,DELETE,OPTIONS",
+		AllowMethods:     "GET,POST,PUT,DELETE,OPTIONS,PATCH",
 		AllowHeaders:     "Origin, Content-Type, Accept, Authorization",
 		AllowCredentials: true,
 	}))

--- a/apps/fe/package-lock.json
+++ b/apps/fe/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.71.1",
         "axios": "^1.8.4",
+        "lodash": "^4.17.21",
         "next": "15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/lodash": "^4.17.16",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1329,6 +1331,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4582,6 +4591,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/apps/fe/package-lock.json
+++ b/apps/fe/package-lock.json
@@ -16,7 +16,6 @@
         "react-dom": "^19.0.0",
         "react-toastify": "^11.0.5",
         "sortablejs": "^1.15.6",
-        "swiper": "^11.2.6",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -5997,25 +5996,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/swiper": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.6.tgz",
-      "integrity": "sha512-8aXpYKtjy3DjcbzZfz+/OX/GhcU5h+looA6PbAzHMZT6ESSycSp9nAjPCenczgJyslV+rUGse64LMGpWE3PX9Q==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/apps/fe/package.json
+++ b/apps/fe/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.71.1",
     "axios": "^1.8.4",
+    "lodash": "^4.17.21",
     "next": "15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/fe/package.json
+++ b/apps/fe/package.json
@@ -17,7 +17,6 @@
     "react-dom": "^19.0.0",
     "react-toastify": "^11.0.5",
     "sortablejs": "^1.15.6",
-    "swiper": "^11.2.6",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/apps/fe/src/app/menu/@deleteModal/delete/page.tsx
+++ b/apps/fe/src/app/menu/@deleteModal/delete/page.tsx
@@ -1,17 +1,21 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useDeleteMenuStore } from '@/stores/useDeleteMenuStore';
 import { useEffect } from 'react';
 
 export default function DeleteMenuModal() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { deleteMenuItem } = useDeleteMenuStore();
 
   const queryId = searchParams.get('id');
   const queryName = searchParams.get('name');
 
   const handleDelete = () => {
-    console.log(`메뉴 ID ${queryId}과 ${queryName} 삭제`);
+    if (deleteMenuItem && queryId) {
+      deleteMenuItem(Number(queryId));
+    }
     router.back();
   };
 

--- a/apps/fe/src/app/menu/@deleteModal/delete/page.tsx
+++ b/apps/fe/src/app/menu/@deleteModal/delete/page.tsx
@@ -37,7 +37,7 @@ export default function DeleteMenuModal() {
         <div className="flex justify-center gap-4">
           <button
             onClick={handleCancel}
-            className="flex-1 w-full px-4 py-2 bg-gray-100 text-label-md text-gray-500 rounded hover:bg-gray-200"
+            className="flex-1 w-full px-4 py-4 bg-gray-100 text-label-md text-gray-500 rounded hover:bg-gray-200"
           >
             취소
           </button>

--- a/apps/fe/src/app/menu/page.tsx
+++ b/apps/fe/src/app/menu/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useManageMenu, IMenu, ISyncLog } from '@/hooks/useManageMenu';
+import { useManageCategory } from '@/hooks/useManageCategory';
 
 import TopNav from '@/components/layout/headers/TopNav';
 import MainControlButton from '@/components/pages/menu/MainControlButton';
@@ -13,16 +15,25 @@ import MenuTextInput from '@/components/pages/menu/MenuTextInput';
 
 import { URLS } from '@/constants/urls';
 
-interface IMenuItem {
-  id: number;
-  name: string;
-  description: string;
-  price: string;
-  category: string;
-  status: string;
-}
-
 export default function MenuPage() {
+  const { menus, isLoading, error, fetchMenus, syncMenus } = useManageMenu();
+  const { categories, fetchCategories } = useManageCategory();
+  const [temporaryMenus, setTemporaryMenus] = useState<IMenu[]>([]);
+  const [changeLogs, setChangeLogs] = useState<ISyncLog[]>([]);
+
+  useEffect(() => {
+    fetchMenus();
+    fetchCategories();
+  }, []);
+
+  useEffect(() => {
+    setTemporaryMenus(menus);
+  }, [menus]);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [categories]);
+
   const [showOnlyEmptyMenus, setShowOnlyEmptyMenus] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
@@ -31,50 +42,33 @@ export default function MenuPage() {
     setShowOnlyEmptyMenus(e.target.checked);
   };
 
-  const [menuItems, setMenuItems] = useState<IMenuItem[]>([
-    {
-      id: 1,
-      name: '이십글자임이십글자임이십글자임이십글자임',
-      description: '맛있는 스테이크',
-      price: '999,999,999',
-      category: '열두글자열두글자열두글자',
-      status: '판매 중',
-    },
-    {
-      id: 2,
-      name: '파스타',
-      description: '크림 파스타',
-      price: '15,800',
-      category: '음료',
-      status: '판매 중',
-    },
-  ]);
+  const handleSynchronize = async () => {
+    await syncMenus(changeLogs);
+  };
   const addMenuItem = () => {
-    setMenuItems((prev) => [
+    setTemporaryMenus((prev) => [
       ...prev,
       {
         id: prev.length + 1,
-        name: '',
-        description: '',
-        price: '',
+        menu: '',
+        price: 0,
         category: '',
         status: '판매 예정',
       },
     ]);
   };
-  const deleteMenuItem = (id: number) => setMenuItems((prev) => prev.filter((item) => item.id !== id));
-  const updateMenuItem = (id: number, field: keyof IMenuItem, value: string | boolean) =>
-    setMenuItems((prev) => prev.map((item) => (item.id === id ? { ...item, [field]: value } : item)));
+  const deleteMenuItem = (id: number) => setTemporaryMenus((prev) => prev.filter((item) => item.id !== id));
+  const updateMenuItem = (id: number, field: keyof IMenu, value: string | boolean) =>
+    setTemporaryMenus((prev) => prev.map((item) => (item.id === id ? { ...item, [field]: value } : item)));
 
-  const [categories, setCategories] = useState(['안주', '증류주', '열두글자열두글자열두글자', '음료']);
   const handleCategoryChange = (id: number, value: string) => updateMenuItem(id, 'category', value);
 
   const [status] = useState(['판매 중', '판매 중단', '판매 예정']);
   const handleStatusChange = (id: number, value: string) => updateMenuItem(id, 'status', value);
 
   const filteredMenuItems = showOnlyEmptyMenus
-    ? menuItems.filter((item) => !item.name || !item.price || !item.category)
-    : menuItems;
+    ? temporaryMenus.filter((item) => !item.menu || !item.price || !item.category)
+    : temporaryMenus;
 
   return (
     <>
@@ -122,7 +116,7 @@ export default function MenuPage() {
                 <td className="items-center">
                   <MenuTextInput
                     variant="menu"
-                    defaultValue={item.name}
+                    defaultValue={item.menu}
                     placeholder="메뉴명"
                     onSave={(value) => updateMenuItem(item.id, 'name', value)}
                     className={`w-full p-1 m-5 rounded text-left`}
@@ -142,7 +136,7 @@ export default function MenuPage() {
 
                 <td className="text-center">
                   <MenuManageSelect
-                    options={categories}
+                    options={categories.map((item) => item.category)}
                     selectedOption={item.category}
                     onChange={(value) => handleCategoryChange(item.id, value)}
                   />
@@ -151,7 +145,7 @@ export default function MenuPage() {
                 <td className="text-center">
                   <MenuManageSelect
                     options={status}
-                    selectedOption={item.status}
+                    selectedOption={'d'}
                     isStatus={true}
                     onChange={(value) => handleStatusChange(item.id, value)}
                   />
@@ -174,7 +168,7 @@ export default function MenuPage() {
                   <Link
                     href={{
                       pathname: '/menu/delete',
-                      query: { id: item.id, name: item.name },
+                      query: { id: item.id, name: item.menu },
                     }}
                   >
                     <ManageButton variant="delete">삭제</ManageButton>
@@ -192,8 +186,7 @@ export default function MenuPage() {
         <CategorySidebar
           isOpen={isSidebarOpen}
           onClose={() => setIsSidebarOpen(false)}
-          categories={categories}
-          setCategories={setCategories}
+          setTemporaryMenus={setTemporaryMenus}
         />
       </div>
     </>

--- a/apps/fe/src/app/menu/page.tsx
+++ b/apps/fe/src/app/menu/page.tsx
@@ -16,6 +16,8 @@ import CategorySidebar from '@/components/layout/sidebars/CategorySidebar';
 import MenuTextInput from '@/components/pages/menu/MenuTextInput';
 
 import { URLS } from '@/constants/urls';
+import { MESSAGES } from '@/constants/messages';
+import Spinner from '@/components/common/loadings/Spinner';
 
 export default function MenuPage() {
   const { menus, isLoading, error, fetchMenus, syncMenus } = useManageMenu();
@@ -35,8 +37,14 @@ export default function MenuPage() {
     fetchCategories();
   }, [categories]);
 
+  useEffect(() => {
+    setIsMenusLoading(isLoading);
+  }, [isLoading]);
+
+  const [isMenusLoading, setIsMenusLoading] = useState<boolean>(true);
   const [temporaryMenus, setTemporaryMenus] = useState<IMenu[]>([]);
   const [changeLogIds, setChangeLogIds] = useState<Set<number>>(new Set());
+  const [menuErrors, setMenuErrors] = useState<Record<number, string>>({});
   const originalMenuDict = useMemo(
     () => menus.reduce((acc, menu) => ({ ...acc, [menu.id]: menu }), {} as Record<number, IMenu>),
     [menus],
@@ -109,7 +117,7 @@ export default function MenuPage() {
       await syncMenus(syncData);
 
       setChangeLogIds(new Set());
-
+      setMenuErrors({});
       fetchMenus();
     } catch (error) {
       console.error('Sync error:', error);
@@ -128,7 +136,7 @@ export default function MenuPage() {
     ]);
   };
   const deleteMenuItem = (id: number) => setTemporaryMenus((prev) => prev.filter((item) => item.id !== id));
-  const updateMenuItem = (id: number, field: keyof IMenu, value: string | boolean) =>
+  const updateMenuItem = (id: number, field: keyof IMenu, value: string | boolean | number) =>
     setTemporaryMenus((prev) => prev.map((item) => (item.id === id ? { ...item, [field]: value } : item)));
 
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -165,6 +173,7 @@ export default function MenuPage() {
             미입력 메뉴만 보기
           </CheckboxInput>
           <MainControlButton
+            variant="menu"
             className="flex-none w-fit mr-3"
             onClick={handleSynchronize}
             disabled={changeLogIds.size === 0}
@@ -176,93 +185,114 @@ export default function MenuPage() {
           </MainControlButton>
         </header>
 
-        <table className="w-full table-auto border-none">
-          <thead className="bg-gray-100 text-gray-800 text-label-sm-sb border-b border-b-gray-400">
-            <tr>
-              <th className="px-5 py-5 w-[10%]">번호</th>
-              <th className="px-5 py-5 w-[35%] text-left">메뉴명</th>
-              <th className="px-5 py-5 w-[10%]">가격</th>
-              <th className="px-5 py-5 w-[15%]">카테고리</th>
-              <th className="px-5 py-5 w-[10%]">상태</th>
-              <th className="px-5 py-5 w-[10%]">이미지 및 설명</th>
-              <th className="px-5 py-5 w-[10%]">삭제</th>
-            </tr>
-          </thead>
+        {isMenusLoading ? (
+          <div className="flex h-100 justify-center items-center">
+            <Spinner className="border-blue-500 w-10 h-10" />
+          </div>
+        ) : (
+          <>
+            <table className="w-full table-auto border-none">
+              <thead className="bg-gray-100 text-gray-800 text-label-sm-sb border-b border-b-gray-400">
+                <tr>
+                  <th className="px-5 py-5 w-[10%]">번호</th>
+                  <th className="px-5 py-5 w-[35%] text-left">메뉴명</th>
+                  <th className="px-5 py-5 w-[10%]">가격</th>
+                  <th className="px-5 py-5 w-[15%]">카테고리</th>
+                  <th className="px-5 py-5 w-[10%]">상태</th>
+                  <th className="px-5 py-5 w-[10%]">이미지 및 설명</th>
+                  <th className="px-5 py-5 w-[10%]">삭제</th>
+                </tr>
+              </thead>
+              <tbody className="text-label-sm-m text-gray-700">
+                {filteredMenuItems.map((item, idx) => (
+                  <tr key={item.id}>
+                    <td className="text-center">{idx + 1}</td>
 
-          <tbody className="text-label-sm-m text-gray-700">
-            {filteredMenuItems.map((item, idx) => (
-              <tr key={item.id}>
-                <td className="text-center">{idx + 1}</td>
+                    <td className="items-center">
+                      <MenuTextInput
+                        variant="menu"
+                        defaultValue={item.menu}
+                        placeholder="메뉴명"
+                        onSave={(value) => updateMenuItem(item.id, 'menu', value)}
+                        className={`w-full p-1 m-5 rounded text-left`}
+                        maxLength={20}
+                      />
+                    </td>
 
-                <td className="items-center">
-                  <MenuTextInput
-                    variant="menu"
-                    defaultValue={item.menu}
-                    placeholder="메뉴명"
-                    onSave={(value) => updateMenuItem(item.id, 'menu', value)}
-                    className={`w-full p-1 m-5 rounded text-left`}
-                    maxLength={20}
-                  />
-                </td>
+                    <td className="text-center">
+                      <MenuTextInput
+                        variant="menu"
+                        defaultValue={item.price.toString()}
+                        placeholder="가격"
+                        onSave={(value) => {
+                          const numericValue = Number(value);
+                          if (isNaN(numericValue)) {
+                            setMenuErrors((prev) => ({
+                              ...prev,
+                              [item.id]: MESSAGES.invalidPriceError,
+                            }));
+                          } else {
+                            setMenuErrors((prev) => {
+                              const { [item.id]: _, ...rest } = prev;
+                              return rest;
+                            });
+                            updateMenuItem(item.id, 'price', numericValue);
+                          }
+                        }}
+                        maxLength={11}
+                        errorMessage={menuErrors[item.id]}
+                      />
+                    </td>
 
-                <td className="text-center">
-                  <MenuTextInput
-                    variant="menu"
-                    defaultValue={item.price}
-                    placeholder="가격"
-                    onSave={(value) => updateMenuItem(item.id, 'price', value)}
-                    maxLength={11}
-                  />
-                </td>
+                    <td className="text-center">
+                      <MenuManageSelect
+                        options={categories.map((item) => item.category)}
+                        selectedOption={item.category}
+                        onChange={(value) => handleCategoryChange(item.id, value)}
+                      />
+                    </td>
 
-                <td className="text-center">
-                  <MenuManageSelect
-                    options={categories.map((item) => item.category)}
-                    selectedOption={item.category}
-                    onChange={(value) => handleCategoryChange(item.id, value)}
-                  />
-                </td>
+                    <td className="text-center">
+                      <MenuManageSelect
+                        options={status}
+                        selectedOption={'d'}
+                        isStatus={true}
+                        onChange={(value) => handleStatusChange(item.id, value)}
+                      />
+                    </td>
 
-                <td className="text-center">
-                  <MenuManageSelect
-                    options={status}
-                    selectedOption={'d'}
-                    isStatus={true}
-                    onChange={(value) => handleStatusChange(item.id, value)}
-                  />
-                </td>
+                    <td className="text-center">
+                      <Link
+                        href={{
+                          pathname: `/menu/modify`,
+                          query: {
+                            id: item.id,
+                          },
+                        }}
+                      >
+                        <ManageButton variant="modify">편집하기</ManageButton>
+                      </Link>
+                    </td>
 
-                <td className="text-center">
-                  <Link
-                    href={{
-                      pathname: `/menu/modify`,
-                      query: {
-                        id: item.id,
-                      },
-                    }}
-                  >
-                    <ManageButton variant="modify">편집하기</ManageButton>
-                  </Link>
-                </td>
-
-                <td className="text-center">
-                  <Link
-                    href={{
-                      pathname: '/menu/delete',
-                      query: { id: item.id, name: item.menu },
-                    }}
-                  >
-                    <ManageButton variant="delete">삭제</ManageButton>
-                  </Link>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-
-        <MainControlButton className="w-full py-5" onClick={addMenuItem}>
-          새로운 메뉴 추가
-        </MainControlButton>
+                    <td className="text-center">
+                      <Link
+                        href={{
+                          pathname: '/menu/delete',
+                          query: { id: item.id, name: item.menu },
+                        }}
+                      >
+                        <ManageButton variant="delete">삭제</ManageButton>
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <MainControlButton className="w-full py-5" onClick={addMenuItem}>
+              새로운 메뉴 추가
+            </MainControlButton>
+          </>
+        )}
 
         <CategorySidebar
           isOpen={isSidebarOpen}

--- a/apps/fe/src/app/menu/page.tsx
+++ b/apps/fe/src/app/menu/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
-import { useManageMenu, IMenu, ISyncLog } from '@/hooks/useManageMenu';
+import { isEqual } from 'lodash';
+import { useManageMenu, IMenu } from '@/hooks/useManageMenu';
 import { useManageCategory } from '@/hooks/useManageCategory';
+import { useDeleteMenuStore } from '@/stores/useDeleteMenuStore';
 
 import TopNav from '@/components/layout/headers/TopNav';
 import MainControlButton from '@/components/pages/menu/MainControlButton';
@@ -18,8 +20,7 @@ import { URLS } from '@/constants/urls';
 export default function MenuPage() {
   const { menus, isLoading, error, fetchMenus, syncMenus } = useManageMenu();
   const { categories, fetchCategories } = useManageCategory();
-  const [temporaryMenus, setTemporaryMenus] = useState<IMenu[]>([]);
-  const [changeLogs, setChangeLogs] = useState<ISyncLog[]>([]);
+  const { setDeleteHandler, clearDeleteHandler } = useDeleteMenuStore();
 
   useEffect(() => {
     fetchMenus();
@@ -34,22 +35,91 @@ export default function MenuPage() {
     fetchCategories();
   }, [categories]);
 
-  const [showOnlyEmptyMenus, setShowOnlyEmptyMenus] = useState(false);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [temporaryMenus, setTemporaryMenus] = useState<IMenu[]>([]);
+  const [changeLogIds, setChangeLogIds] = useState<Set<number>>(new Set());
+  const originalMenuDict = useMemo(
+    () => menus.reduce((acc, menu) => ({ ...acc, [menu.id]: menu }), {} as Record<number, IMenu>),
+    [menus],
+  );
+  const tempMenuDict = useMemo(
+    () => temporaryMenus.reduce((acc, menu) => ({ ...acc, [menu.id]: menu }), {} as Record<number, IMenu>),
+    [temporaryMenus],
+  );
+  useEffect(() => {
+    const changedIds = Object.keys(tempMenuDict)
+      .filter((id) => {
+        const menuId = Number(id);
+        const original = originalMenuDict[menuId];
+        const current = tempMenuDict[menuId];
 
-  const toggleSidebar = () => setIsSidebarOpen((prev) => !prev);
-  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setShowOnlyEmptyMenus(e.target.checked);
-  };
+        return !original || !isEqual(original, current);
+      })
+      .map(Number);
 
+    const deletedIds = Object.keys(originalMenuDict)
+      .filter((id) => !tempMenuDict.hasOwnProperty(id))
+      .map(Number);
+
+    setChangeLogIds(new Set([...changedIds, ...deletedIds]));
+    console.log(changedIds, deletedIds);
+  }, [originalMenuDict, tempMenuDict]);
+  useEffect(() => {
+    setDeleteHandler(deleteMenuItem);
+    return () => clearDeleteHandler();
+  }, [setDeleteHandler, clearDeleteHandler]);
   const handleSynchronize = async () => {
-    await syncMenus(changeLogs);
+    const changedIds = Array.from(changeLogIds);
+
+    const syncData = changedIds.map((id) => {
+      const original = menus.find((m) => m.id === id);
+      const current = temporaryMenus.find((m) => m.id === id);
+
+      if (id < 0 || !original) {
+        return {
+          action: 'create' as const,
+          id: -1,
+          data: {
+            menu: current?.menu || '',
+            price: current?.price || 0,
+            categoryId: categories.find((c) => c.category === current?.category)?.id || 0,
+            soldOut: current?.status === '판매 예정',
+          },
+        };
+      }
+      if (!current) {
+        return {
+          action: 'delete' as const,
+          id,
+          data: {},
+        };
+      }
+      return {
+        action: 'update' as const,
+        id,
+        data: {
+          menu: current.menu,
+          price: current.price,
+          categoryId: categories.find((c) => c.category === current.category)?.id || 0,
+          soldOut: current.status === '판매 중단',
+        },
+      };
+    });
+
+    try {
+      await syncMenus(syncData);
+
+      setChangeLogIds(new Set());
+
+      fetchMenus();
+    } catch (error) {
+      console.error('Sync error:', error);
+    }
   };
   const addMenuItem = () => {
     setTemporaryMenus((prev) => [
       ...prev,
       {
-        id: prev.length + 1,
+        id: -Date.now(),
         menu: '',
         price: 0,
         category: '',
@@ -61,11 +131,15 @@ export default function MenuPage() {
   const updateMenuItem = (id: number, field: keyof IMenu, value: string | boolean) =>
     setTemporaryMenus((prev) => prev.map((item) => (item.id === id ? { ...item, [field]: value } : item)));
 
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const toggleSidebar = () => setIsSidebarOpen((prev) => !prev);
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => setShowOnlyEmptyMenus(e.target.checked);
   const handleCategoryChange = (id: number, value: string) => updateMenuItem(id, 'category', value);
 
   const [status] = useState(['판매 중', '판매 중단', '판매 예정']);
   const handleStatusChange = (id: number, value: string) => updateMenuItem(id, 'status', value);
 
+  const [showOnlyEmptyMenus, setShowOnlyEmptyMenus] = useState(false);
   const filteredMenuItems = showOnlyEmptyMenus
     ? temporaryMenus.filter((item) => !item.menu || !item.price || !item.category)
     : temporaryMenus;
@@ -90,6 +164,13 @@ export default function MenuPage() {
           <CheckboxInput checked={showOnlyEmptyMenus} onChange={handleCheckboxChange}>
             미입력 메뉴만 보기
           </CheckboxInput>
+          <MainControlButton
+            className="flex-none w-fit mr-3"
+            onClick={handleSynchronize}
+            disabled={changeLogIds.size === 0}
+          >
+            변경사항 저장하기
+          </MainControlButton>
           <MainControlButton variant="category" className="flex-none w-fit" onClick={toggleSidebar}>
             카테고리 편집
           </MainControlButton>
@@ -118,7 +199,7 @@ export default function MenuPage() {
                     variant="menu"
                     defaultValue={item.menu}
                     placeholder="메뉴명"
-                    onSave={(value) => updateMenuItem(item.id, 'name', value)}
+                    onSave={(value) => updateMenuItem(item.id, 'menu', value)}
                     className={`w-full p-1 m-5 rounded text-left`}
                     maxLength={20}
                   />

--- a/apps/fe/src/app/menu/page.tsx
+++ b/apps/fe/src/app/menu/page.tsx
@@ -90,7 +90,7 @@ export default function MenuPage() {
             menu: current?.menu || '',
             price: current?.price || 0,
             categoryId: categories.find((c) => c.category === current?.category)?.id || 0,
-            soldOut: current?.status === '판매 예정',
+            status: current?.status,
           },
         };
       }
@@ -108,7 +108,7 @@ export default function MenuPage() {
           menu: current.menu,
           price: current.price,
           categoryId: categories.find((c) => c.category === current.category)?.id || 0,
-          soldOut: current.status === '판매 중단',
+          status: current.status,
         },
       };
     });
@@ -145,7 +145,10 @@ export default function MenuPage() {
   const handleCategoryChange = (id: number, value: string) => updateMenuItem(id, 'category', value);
 
   const [status] = useState(['판매 중', '판매 중단', '판매 예정']);
-  const handleStatusChange = (id: number, value: string) => updateMenuItem(id, 'status', value);
+  const handleStatusChange = (id: number, value: string) => {
+    updateMenuItem(id, 'status', value);
+    console.log('value: ', value);
+  };
 
   const [showOnlyEmptyMenus, setShowOnlyEmptyMenus] = useState(false);
   const filteredMenuItems = showOnlyEmptyMenus
@@ -255,7 +258,7 @@ export default function MenuPage() {
                     <td className="text-center">
                       <MenuManageSelect
                         options={status}
-                        selectedOption={'d'}
+                        selectedOption={item.status || '판매 예정'}
                         isStatus={true}
                         onChange={(value) => handleStatusChange(item.id, value)}
                       />

--- a/apps/fe/src/components/common/buttons/BaseButton.tsx
+++ b/apps/fe/src/components/common/buttons/BaseButton.tsx
@@ -22,7 +22,7 @@ export default function BaseButton({
 
   return (
     <button className={`${baseClass} ${variantClass} ${className}`} disabled={isLoading || props.disabled} {...props}>
-      {isLoading ? <Spinner /> : children || '버튼'}
+      {isLoading ? <Spinner className="border-white" /> : children || '버튼'}
     </button>
   );
 }

--- a/apps/fe/src/components/common/loadings/Spinner.tsx
+++ b/apps/fe/src/components/common/loadings/Spinner.tsx
@@ -1,3 +1,5 @@
-export default function Spinner() {
-  return <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />;
+interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export default function Spinner({ className, ...props }: SpinnerProps) {
+  return <div className={`w-4 h-4 border-2 border-t-transparent rounded-full animate-spin ${className}`} {...props} />;
 }

--- a/apps/fe/src/components/layout/sidebars/CategorySidebar.tsx
+++ b/apps/fe/src/components/layout/sidebars/CategorySidebar.tsx
@@ -1,21 +1,24 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
-import { toast } from 'react-toastify';
+import { useManageCategory } from '@/hooks/useManageCategory';
 import { MESSAGES } from '@/constants/messages';
+
 import TextInput from '@/components/common/inputs/TextInput';
 import MenuTextInput from '@/components/pages/menu/MenuTextInput';
-import { useCategory, ICategory } from '@/hooks/useCategory';
-import trashcanIcon from '@public/icons/ic_trashcan.svg';
 import Spinner from '@/components/common/loadings/Spinner';
+
+import trashcanIcon from '@public/icons/ic_trashcan.svg';
 
 interface CategorySidebarProps {
   isOpen: boolean;
   onClose: () => void;
+  setTemporaryMenus: React.Dispatch<React.SetStateAction<any[]>>;
 }
 
-export default function CategorySidebar({ isOpen, onClose }: CategorySidebarProps) {
+export default function CategorySidebar({ isOpen, onClose, setTemporaryMenus }: CategorySidebarProps) {
   const sidebarRef = useRef<HTMLDivElement>(null);
-  const { categories, isLoading, error, create, fetch, update, remove } = useCategory();
+  const { categories, isLoading, error, createCategory, fetchCategories, updateCategory, removeCategory } =
+    useManageCategory();
 
   const [isComposing, setIsComposing] = useState(false);
   const [newCategory, setNewCategory] = useState('');
@@ -23,7 +26,7 @@ export default function CategorySidebar({ isOpen, onClose }: CategorySidebarProp
 
   useEffect(() => {
     if (isOpen) {
-      fetch();
+      fetchCategories();
     }
   }, [isOpen]);
 
@@ -54,14 +57,20 @@ export default function CategorySidebar({ isOpen, onClose }: CategorySidebarProp
         setCategoryError(MESSAGES.emptyCategoryError);
         return;
       }
-      await create(inputValue);
+      await createCategory(inputValue);
       setNewCategory('');
       setCategoryError(null);
     }
   };
 
   const handleDeleteCategory = async (categoryId: number) => {
-    await remove(categoryId);
+    await removeCategory(categoryId);
+    const deletedCategory = categories.find((category) => category.id === categoryId)?.category;
+    if (deletedCategory) {
+      setTemporaryMenus((prevMenus) =>
+        prevMenus.map((menu) => (menu.category === deletedCategory ? { ...menu, category: null } : menu)),
+      );
+    }
   };
 
   const handleSaveEdit = async (
@@ -78,7 +87,7 @@ export default function CategorySidebar({ isOpen, onClose }: CategorySidebarProp
       }
       event.preventDefault?.();
       if (updatedCategory.trim() === '') return;
-      await update(categoryId, updatedCategory);
+      await updateCategory(categoryId, updatedCategory);
     }
   };
 

--- a/apps/fe/src/components/layout/sidebars/CategorySidebar.tsx
+++ b/apps/fe/src/components/layout/sidebars/CategorySidebar.tsx
@@ -1,26 +1,31 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
-
+import { toast } from 'react-toastify';
+import { MESSAGES } from '@/constants/messages';
 import TextInput from '@/components/common/inputs/TextInput';
 import MenuTextInput from '@/components/pages/menu/MenuTextInput';
-
-import { MESSAGES } from '@/constants/messages';
-
+import { useCategory, ICategory } from '@/hooks/useCategory';
 import trashcanIcon from '@public/icons/ic_trashcan.svg';
+import Spinner from '@/components/common/loadings/Spinner';
 
 interface CategorySidebarProps {
   isOpen: boolean;
   onClose: () => void;
-  categories: string[];
-  setCategories: (categories: string[]) => void;
 }
 
-export default function CategorySidebar({ isOpen, onClose, categories, setCategories }: CategorySidebarProps) {
+export default function CategorySidebar({ isOpen, onClose }: CategorySidebarProps) {
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const { categories, isLoading, error, create, fetch, update, remove } = useCategory();
 
   const [isComposing, setIsComposing] = useState(false);
   const [newCategory, setNewCategory] = useState('');
   const [categoryError, setCategoryError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetch();
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -28,48 +33,53 @@ export default function CategorySidebar({ isOpen, onClose, categories, setCatego
         onClose();
       }
     };
-
     if (isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
     }
-
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isOpen, onClose]);
-  const handleDeleteCategory = (index: number) => {
-    const updatedCategories = categories.filter((_, i) => i !== index);
-    setCategories(updatedCategories);
-  };
-  const handleAddCategory = (event: React.KeyboardEvent<HTMLInputElement>) => {
+
+  const handleAddCategory = async (event: React.KeyboardEvent<HTMLInputElement>) => {
     const inputValue = (event.target as HTMLInputElement).value.trim();
-
     if (isComposing) return;
-
     if (event.key === 'Enter' && inputValue) {
       event.preventDefault();
-
       if (categories.length >= 999) {
         setCategoryError(MESSAGES.maximumCategoryError);
         return;
       }
-
-      if (categories.includes(inputValue)) {
-        setCategoryError(MESSAGES.duplicatedCategoryError);
+      if (inputValue === '') {
+        setCategoryError(MESSAGES.emptyCategoryError);
         return;
       }
-
-      const updatedCategories = [...categories, inputValue];
-      setCategories(updatedCategories);
-      setCategoryError('');
+      await create(inputValue);
       setNewCategory('');
+      setCategoryError(null);
     }
   };
-  const handleSaveEdit = (index: number, newText: string) => {
-    if (newText.trim() === '') return;
-    const updated = [...categories];
-    updated[index] = newText;
-    setCategories(updated);
+
+  const handleDeleteCategory = async (categoryId: number) => {
+    await remove(categoryId);
+  };
+
+  const handleSaveEdit = async (
+    event: React.KeyboardEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>,
+    categoryId: number,
+    updatedCategory: string,
+  ) => {
+    if (isComposing) return;
+
+    if ((event.type === 'keydown' && (event as React.KeyboardEvent).key === 'Enter') || event.type === 'blur') {
+      if (event.type === 'keydown') {
+        (event.target as HTMLInputElement).blur();
+        return;
+      }
+      event.preventDefault?.();
+      if (updatedCategory.trim() === '') return;
+      await update(categoryId, updatedCategory);
+    }
   };
 
   return (
@@ -97,15 +107,25 @@ export default function CategorySidebar({ isOpen, onClose, categories, setCatego
             label="카테고리"
             onCompositionStart={() => setIsComposing(true)}
             onCompositionEnd={() => setIsComposing(false)}
-            onChange={(e) => setNewCategory(e.target.value)}
+            onChange={(e) => {
+              setNewCategory(e.target.value);
+              setCategoryError(null);
+            }}
             onKeyDown={handleAddCategory}
             maxLength={12}
-            errorMessage={categoryError ?? undefined}
+            errorMessage={categoryError || error || undefined}
+            disabled={isLoading}
           />
 
           <div className="text-label-xs-m text-gray-700 py-5">카테고리 목록</div>
 
-          {categories && categories.length > 0 ? (
+          {isLoading ? (
+            <Spinner />
+          ) : categories == null || categories.length === 0 ? (
+            <div className="bg-gray-100 text-gray-400 text-body-xs text-center py-10 rounded-sm">
+              추가된 카테고리가 없습니다.\n새로운 카테고리를 입력해 주세요.
+            </div>
+          ) : (
             <ul className="space-y-2">
               {categories.map((category, index) => (
                 <li key={index} className="flex justify-between items-center p-2 rounded-md">
@@ -113,31 +133,27 @@ export default function CategorySidebar({ isOpen, onClose, categories, setCatego
                     <div className="text-gray-500 text-label-xs-m border border-gray-200 px-1 mr-2 select-none">
                       {(index + 1).toString().padStart(3, '0')}
                     </div>
-
                     <MenuTextInput
                       variant="category"
-                      defaultValue={category}
+                      defaultValue={category.category}
                       placeholder="카테고리"
-                      onSave={(value) => handleSaveEdit(index, value)}
+                      onCompositionStart={() => setIsComposing(true)}
+                      onCompositionEnd={() => setIsComposing(false)}
+                      onKeyDown={(event) => handleSaveEdit(event, category.id, event.currentTarget.value)}
+                      onBlur={(event) => handleSaveEdit(event, category.id, event.currentTarget.value)}
                       maxLength={12}
                     />
                   </div>
-
                   <button
                     className="text-red-500 border border-red-200 bg-red-100 p-1 rounded-sm hover:bg-red-200 focus:outline-none"
-                    onClick={() => handleDeleteCategory(index)}
+                    onClick={() => handleDeleteCategory(category.id)}
+                    disabled={isLoading}
                   >
                     <Image className="w-3 h-3" src={trashcanIcon} alt="삭제" draggable="false" />
                   </button>
                 </li>
               ))}
             </ul>
-          ) : (
-            <div className="bg-gray-100 text-gray-400 text-body-xs-m text-center py-10 rounded-sm">
-              추가된 카테고리가 없습니다
-              <br />
-              새로운 카테고리를 입력해 주세요
-            </div>
           )}
         </div>
       </div>

--- a/apps/fe/src/components/pages/menu/MainControlButton.tsx
+++ b/apps/fe/src/components/pages/menu/MainControlButton.tsx
@@ -1,7 +1,7 @@
 import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 
 interface MainControlButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, PropsWithChildren {
-  variant?: 'default' | 'category';
+  variant?: 'default' | 'category' | 'menu';
 }
 
 export default function MainControlButton({
@@ -10,12 +10,15 @@ export default function MainControlButton({
   className = '',
   ...props
 }: MainControlButtonProps) {
-  const baseClass = 'w-fit px-3 py-3 text-label-md rounded-[4px] border border-gray-200 focus:outline-none transition';
+  const baseClass =
+    'w-fit px-3 py-3 text-label-md rounded-[4px] border border-gray-200 focus:outline-none transition select-none';
 
   const variantClass =
     variant === 'category'
       ? 'bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:bg-gray-300'
-      : 'bg-white text-gray-600 hover:bg-gray-100 disabled:bg-gray-200 disabled:text-gray-300';
+      : variant === 'menu'
+        ? 'bg-blue-500 text-blue-100 hover:bg-blue-400 disabled:bg-gray-200 disabled:text-gray-300'
+        : 'bg-white text-gray-600 hover:bg-gray-100 disabled:bg-gray-200 disabled:text-gray-300';
 
   return (
     <button className={`${baseClass} ${variantClass} ${className}`} {...props}>

--- a/apps/fe/src/components/pages/menu/MenuElementLabel.tsx
+++ b/apps/fe/src/components/pages/menu/MenuElementLabel.tsx
@@ -16,7 +16,7 @@ export default function MenuElementLabel({
   onClick,
 }: MenuElementLabelProps) {
   const baseClass =
-    'inline-flex items-center text-label-sm-m border rounded-[4px] focus:outline-none transition select-none';
+    'inline-flex items-center text-label-sm-m border rounded-sm focus:outline-none transition select-none';
 
   if (isStatus) {
     if (text === '판매 중') {

--- a/apps/fe/src/components/pages/menu/MenuManageSelect.tsx
+++ b/apps/fe/src/components/pages/menu/MenuManageSelect.tsx
@@ -21,7 +21,6 @@ export default function MenuManageSelect({
   const [isOpen, setIsOpen] = useState(false);
   const selectRef = useRef<HTMLDivElement>(null);
 
-  // 외부 클릭 감지
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (selectRef.current && !selectRef.current.contains(event.target as Node)) {
@@ -34,14 +33,13 @@ export default function MenuManageSelect({
     };
   }, []);
 
-  // 선택된 옵션의 텍스트 길이를 기준으로 left 값 계산
   const calculateLeftPosition = (text: string) => {
-    const fontSize = 16; // 텍스트의 폰트 크기 (픽셀)
-    const averageCharacterWidth = fontSize * 1; // 문자당 평균 너비 계산
-    return (text.length / 2) * averageCharacterWidth + 4; // 글자 길이에 따른 left 값 계산 (+4px)
+    const fontSize = 16;
+    const averageCharacterWidth = fontSize * 1;
+    return (text.length / 2) * averageCharacterWidth + 4;
   };
 
-  const leftPosition = calculateLeftPosition(selectedOption || '카테고리 선택'); // 기본값 포함
+  const leftPosition = calculateLeftPosition(selectedOption || '카테고리 선택');
 
   return (
     <div className="relative inline-block w-full cursor-pointer" ref={selectRef}>
@@ -56,7 +54,7 @@ export default function MenuManageSelect({
       {isOpen && (
         <div
           className="absolute z-10 top-0 w-full bg-white border border-gray-200 rounded shadow-lg"
-          style={{ left: `calc(50% + ${leftPosition}px)` }} // 동적으로 계산된 left 값 적용
+          style={{ left: `calc(50% + ${leftPosition}px)` }}
         >
           {options.map((option) => (
             <div

--- a/apps/fe/src/components/pages/menu/MenuTextInput.tsx
+++ b/apps/fe/src/components/pages/menu/MenuTextInput.tsx
@@ -1,26 +1,27 @@
 import React, { useState, useEffect, useRef, InputHTMLAttributes } from 'react';
+import ErrorMessage from '@/components/common/labels/ErrorMessage';
 
 interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  variant: 'menu' | 'category'; // 입력 방식 구분
-  onSave?: (value: string) => void; // 저장 시 호출되는 콜백
+  variant: 'menu' | 'category';
+  onSave?: (value: string) => void;
+  errorMessage?: string;
 }
 
 export default function MenuTextInput({
   variant,
-  defaultValue = '',
   onSave,
+  errorMessage,
+  defaultValue = '',
   className = '',
   ...props
 }: TextInputProps) {
   const [internalValue, setInternalValue] = useState(defaultValue);
-  const inputRef = useRef<HTMLInputElement>(null); // input 요소 참조
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // 외부 defaultValue 변경 시 내부 상태 동기화
   useEffect(() => {
     setInternalValue(defaultValue);
   }, [defaultValue]);
 
-  // 텍스트 길이에 따라 너비 조정
   useEffect(() => {
     if (inputRef.current) {
       const tempSpan = document.createElement('span');
@@ -42,23 +43,26 @@ export default function MenuTextInput({
   };
 
   return (
-    <input
-      ref={inputRef}
-      value={internalValue}
-      onChange={(e) => setInternalValue(e.target.value)}
-      onBlur={handleSave}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') {
-          e.preventDefault();
-          (e.target as HTMLInputElement).blur();
-        }
-      }}
-      className={`w-full rounded ${
-        variant === 'menu'
-          ? 'p-1 text-center'
-          : 'bg-gray-100 border border-gray-300 px-[6px] py-[4px] text-label-xs-m text-gray-700 focus:outline-none transition'
-      } ${className}`}
-      {...props}
-    />
+    <div className="flex flex-col">
+      <input
+        ref={inputRef}
+        value={internalValue}
+        onChange={(e) => setInternalValue(e.target.value)}
+        onBlur={handleSave}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        className={`w-full rounded ${
+          variant === 'menu'
+            ? 'p-1 text-center'
+            : 'bg-gray-100 border border-gray-300 px-[6px] py-[4px] text-label-xs-m text-gray-700 focus:outline-none transition'
+        } ${className}`}
+        {...props}
+      />
+      {errorMessage && <ErrorMessage className="mt-1 ml-1 text-left">{errorMessage}</ErrorMessage>}
+    </div>
   );
 }

--- a/apps/fe/src/constants/messages.ts
+++ b/apps/fe/src/constants/messages.ts
@@ -8,5 +8,12 @@ export const MESSAGES = {
   loginSuccess: '로그인에 성공했습니다.',
   maximumTagError: '태그는 최대 10개까지만 입력할 수 있습니다.',
   maximumCategoryError: '태그는 최대 999개까지만 입력할 수 있습니다.',
+  emptyCategoryError: '카테고리명은 1자 이상 12자 이하로 입력해 주세요.',
   duplicatedCategoryError: '카테고리 이름은 중복될 수 없습니다.',
+  badRequestError: '잘못된 요청입니다.',
+  authenticationError: '로그인이 필요한 서비스입니다.',
+  unknownCategoryError: '해당 카테고리를 찾을 수 없습니다.',
+  createCategorySuccess: '카테고리 생성에 성공했습니다.',
+  updateCategorySuccess: '카테고리 수정에 성공했습니다.',
+  deleteCategorySuccess: '카테고리 삭제에 성공했습니다.',
 };

--- a/apps/fe/src/constants/messages.ts
+++ b/apps/fe/src/constants/messages.ts
@@ -16,5 +16,5 @@ export const MESSAGES = {
   createCategorySuccess: '카테고리 생성에 성공했습니다.',
   updateCategorySuccess: '카테고리 수정에 성공했습니다.',
   deleteCategorySuccess: '카테고리 삭제에 성공했습니다.',
-  syncMenusSuccess: '메뉴 수정에 성공했습니다.',
+  syncMenusSuccess: '변경사항 저장에 성공했습니다.',
 };

--- a/apps/fe/src/constants/messages.ts
+++ b/apps/fe/src/constants/messages.ts
@@ -16,5 +16,6 @@ export const MESSAGES = {
   createCategorySuccess: '카테고리 생성에 성공했습니다.',
   updateCategorySuccess: '카테고리 수정에 성공했습니다.',
   deleteCategorySuccess: '카테고리 삭제에 성공했습니다.',
+  invalidPriceError: '가격은 숫자만 입력할 수 있습니다.',
   syncMenusSuccess: '변경사항 저장에 성공했습니다.',
 };

--- a/apps/fe/src/constants/messages.ts
+++ b/apps/fe/src/constants/messages.ts
@@ -16,4 +16,5 @@ export const MESSAGES = {
   createCategorySuccess: '카테고리 생성에 성공했습니다.',
   updateCategorySuccess: '카테고리 수정에 성공했습니다.',
   deleteCategorySuccess: '카테고리 삭제에 성공했습니다.',
+  syncMenusSuccess: '메뉴 수정에 성공했습니다.',
 };

--- a/apps/fe/src/hooks/useCategory.ts
+++ b/apps/fe/src/hooks/useCategory.ts
@@ -1,0 +1,102 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { MESSAGES } from '@/constants/messages';
+import { CategoryAPI } from '@/services/category';
+import { handelError } from '@/services/handleError';
+
+export interface ICategory {
+  id: number;
+  category: string;
+}
+
+export const useCategory = () => {
+  const [categories, setCategories] = useState<ICategory[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const create = async (categoryName: string) => {
+    if (categories.some((cat) => cat.category === categoryName)) {
+      toast.error(MESSAGES.duplicatedCategoryError);
+      return;
+    }
+    try {
+      const newCategory = await CategoryAPI.addCategory(categoryName);
+      setCategories((prev) => [...prev, newCategory]);
+      toast.success(MESSAGES.createCategorySuccess);
+    } catch (error: any) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        setError(MESSAGES.badRequestError);
+      } else if (error.response?.status === 401) {
+        setError(MESSAGES.authenticationError);
+      } else {
+        handelError(error);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const fetch = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await CategoryAPI.getCategories();
+      setCategories(response);
+    } catch (error: any) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        setError(MESSAGES.authenticationError);
+      } else {
+        handelError(error);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const update = async (categoryId: number, updatedCategory: string) => {
+    try {
+      const updatedCategoryResponse = await CategoryAPI.updateCategory(categoryId, updatedCategory);
+      const updatedCategories = categories.map((category) =>
+        category.id === categoryId ? updatedCategoryResponse : category,
+      );
+      setCategories(updatedCategories);
+      toast.success(MESSAGES.updateCategorySuccess);
+    } catch (error: any) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        setError(MESSAGES.badRequestError);
+      } else if (error.response?.status === 401) {
+        setError(MESSAGES.authenticationError);
+      } else if (error.response?.status === 404) {
+        setError(MESSAGES.unknownCategoryError);
+      } else {
+        handelError(error);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const remove = async (categoryId: number) => {
+    try {
+      const responseMessage = await CategoryAPI.deleteCategory(categoryId);
+      const updatedCategories = categories.filter((category) => category.id !== categoryId);
+      setCategories(updatedCategories);
+      toast.success(MESSAGES.deleteCategorySuccess);
+    } catch (error: any) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        setError(MESSAGES.badRequestError);
+      } else if (error.response?.status === 401) {
+        setError(MESSAGES.authenticationError);
+      } else if (error.response?.status === 404) {
+        setError(MESSAGES.unknownCategoryError);
+      } else {
+        handelError(error);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { categories, isLoading, error, create, fetch, update, remove };
+};

--- a/apps/fe/src/hooks/useManageCategory.ts
+++ b/apps/fe/src/hooks/useManageCategory.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { MESSAGES } from '@/constants/messages';
-import { CategoryAPI } from '@/services/category';
+import { CategoryAPI } from '@/services/manageMenu';
 import { handelError } from '@/services/handleError';
 
 export interface ICategory {
@@ -10,12 +10,12 @@ export interface ICategory {
   category: string;
 }
 
-export const useCategory = () => {
+export const useManageCategory = () => {
   const [categories, setCategories] = useState<ICategory[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const create = async (categoryName: string) => {
+  const createCategory = async (categoryName: string) => {
     if (categories.some((cat) => cat.category === categoryName)) {
       toast.error(MESSAGES.duplicatedCategoryError);
       return;
@@ -37,7 +37,7 @@ export const useCategory = () => {
     }
   };
 
-  const fetch = async () => {
+  const fetchCategories = async () => {
     setIsLoading(true);
     setError(null);
     try {
@@ -54,7 +54,7 @@ export const useCategory = () => {
     }
   };
 
-  const update = async (categoryId: number, updatedCategory: string) => {
+  const updateCategory = async (categoryId: number, updatedCategory: string) => {
     try {
       const updatedCategoryResponse = await CategoryAPI.updateCategory(categoryId, updatedCategory);
       const updatedCategories = categories.map((category) =>
@@ -77,7 +77,7 @@ export const useCategory = () => {
     }
   };
 
-  const remove = async (categoryId: number) => {
+  const removeCategory = async (categoryId: number) => {
     try {
       const responseMessage = await CategoryAPI.deleteCategory(categoryId);
       const updatedCategories = categories.filter((category) => category.id !== categoryId);
@@ -98,5 +98,5 @@ export const useCategory = () => {
     }
   };
 
-  return { categories, isLoading, error, create, fetch, update, remove };
+  return { categories, isLoading, error, createCategory, fetchCategories, updateCategory, removeCategory };
 };

--- a/apps/fe/src/hooks/useManageMenu.ts
+++ b/apps/fe/src/hooks/useManageMenu.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { MESSAGES } from '@/constants/messages';
+import { MenuyAPI } from '@/services/manageMenu';
+import { handelError } from '@/services/handleError';
+
+export interface IMenu {
+  id: number;
+  menu: string;
+  price: number;
+  category: string;
+  status: string;
+}
+
+export interface ISyncLog {
+  action: 'create' | 'update' | 'delete';
+  id: number;
+  data: Record<string, any>;
+}
+
+export const useManageMenu = () => {
+  const [menus, setMenus] = useState<IMenu[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMenus = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await MenuyAPI.getMenus();
+      setMenus(response);
+    } catch (error: any) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        setError(MESSAGES.authenticationError);
+      } else {
+        handelError(error);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const syncMenus = async (syncData: any) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await MenuyAPI.syncMenus(syncData);
+      toast.success(MESSAGES.syncMenusSuccess);
+      fetchMenus();
+      return response;
+    } catch (error: any) {
+      if (axios.isAxiosError(error)) {
+        handelError(error);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { menus, isLoading, error, fetchMenus, syncMenus };
+};

--- a/apps/fe/src/services/auth.ts
+++ b/apps/fe/src/services/auth.ts
@@ -6,9 +6,6 @@ export const AuthAPI = {
       UserId: email,
       Password: password,
     });
-
-    console.log('res: ', res);
-
     return res.data;
   },
 };

--- a/apps/fe/src/services/category.ts
+++ b/apps/fe/src/services/category.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '.';
+
+export const CategoryAPI = {
+  getCategories: async () => {
+    const res = await axiosInstance.get('/categories');
+    return res.data;
+  },
+
+  addCategory: async (category: string) => {
+    const res = await axiosInstance.post('/categories', {
+      category,
+    });
+    return res.data;
+  },
+
+  updateCategory: async (categoryId: number, updatedCategory: string) => {
+    const res = await axiosInstance.patch(`/categories/${categoryId}`, {
+      category: updatedCategory,
+    });
+    return res.data;
+  },
+
+  deleteCategory: async (categoryId: number) => {
+    const res = await axiosInstance.delete(`/categories/${categoryId}`);
+    return res.data;
+  },
+};

--- a/apps/fe/src/services/manageMenu.ts
+++ b/apps/fe/src/services/manageMenu.ts
@@ -25,3 +25,14 @@ export const CategoryAPI = {
     return res.data;
   },
 };
+
+export const MenuyAPI = {
+  getMenus: async () => {
+    const res = await axiosInstance.get('/menus');
+    return res.data;
+  },
+  syncMenus: async (syncData: any) => {
+    const res = await axiosInstance.post('/menus/sync', syncData);
+    return res.data;
+  },
+};

--- a/apps/fe/src/services/manageMenu.ts
+++ b/apps/fe/src/services/manageMenu.ts
@@ -32,7 +32,7 @@ export const MenuyAPI = {
     return res.data;
   },
   syncMenus: async (syncData: any) => {
-    const res = await axiosInstance.post('/menus/sync', syncData);
+    const res = await axiosInstance.post('/menus', syncData);
     return res.data;
   },
 };

--- a/apps/fe/src/stores/useDeleteMenuStore.ts
+++ b/apps/fe/src/stores/useDeleteMenuStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface DeleteMenuStore {
+  deleteMenuItem: ((id: number) => void) | null;
+  setDeleteHandler: (handler: (id: number) => void) => void;
+  clearDeleteHandler: () => void;
+}
+
+export const useDeleteMenuStore = create<DeleteMenuStore>((set) => ({
+  deleteMenuItem: null,
+  setDeleteHandler: (handler) => set({ deleteMenuItem: handler }),
+  clearDeleteHandler: () => set({ deleteMenuItem: null }),
+}));

--- a/backup_sikdorang.sql
+++ b/backup_sikdorang.sql
@@ -1,0 +1,259 @@
+-- MySQL dump 10.13  Distrib 9.0.1, for macos15.1 (arm64)
+--
+-- Host: localhost    Database: sikdorang
+-- ------------------------------------------------------
+-- Server version	9.0.1
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `categories`
+--
+
+DROP TABLE IF EXISTS `categories`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `categories` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `category` longtext,
+  `store_id` bigint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_stores_categories` (`store_id`),
+  CONSTRAINT `fk_stores_categories` FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `categories`
+--
+
+LOCK TABLES `categories` WRITE;
+/*!40000 ALTER TABLE `categories` DISABLE KEYS */;
+INSERT INTO `categories` VALUES (1,'시즌 메뉴',1),(2,'음식',1),(3,'막걸리',1),(4,'프리미엄 탁주',1),(5,'청주',1),(6,'약주',1),(7,'증류식 소주, 리큐르',1),(8,'지화자 PICK! 전통주',1);
+/*!40000 ALTER TABLE `categories` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `images`
+--
+
+DROP TABLE IF EXISTS `images`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `images` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `image_url` longtext,
+  `menu_id` bigint unsigned DEFAULT NULL,
+  `store_id` bigint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_menus_images` (`menu_id`),
+  KEY `fk_stores_images` (`store_id`),
+  CONSTRAINT `fk_menus_images` FOREIGN KEY (`menu_id`) REFERENCES `menus` (`id`),
+  CONSTRAINT `fk_stores_images` FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `images`
+--
+
+LOCK TABLES `images` WRITE;
+/*!40000 ALTER TABLE `images` DISABLE KEYS */;
+/*!40000 ALTER TABLE `images` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `menus`
+--
+
+DROP TABLE IF EXISTS `menus`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `menus` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `menu` longtext,
+  `preview` longtext,
+  `details` longtext,
+  `price` bigint DEFAULT NULL,
+  `category_id` bigint unsigned DEFAULT NULL,
+  `store_id` bigint unsigned DEFAULT NULL,
+  `sold_out` tinyint(1) DEFAULT NULL,
+  `order` bigint DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_categories_menus` (`category_id`),
+  KEY `fk_stores_menus` (`store_id`),
+  CONSTRAINT `fk_categories_menus` FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`),
+  CONSTRAINT `fk_stores_menus` FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `menus`
+--
+
+LOCK TABLES `menus` WRITE;
+/*!40000 ALTER TABLE `menus` DISABLE KEYS */;
+INSERT INTO `menus` VALUES (1,'파스타','파스타입니다','파스타입니다다다',12000,1,1,0,1),(2,'스테이크','스테이크입니다','파스타입니다다다',24000,2,1,0,2),(3,'딸깎','딸깎인데요','딸깎이라고',39000,3,1,0,3);
+/*!40000 ALTER TABLE `menus` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `recommand_keywords`
+--
+
+DROP TABLE IF EXISTS `recommand_keywords`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `recommand_keywords` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `keyword1` longtext,
+  `keyword2` longtext,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `recommand_keywords`
+--
+
+LOCK TABLES `recommand_keywords` WRITE;
+/*!40000 ALTER TABLE `recommand_keywords` DISABLE KEYS */;
+/*!40000 ALTER TABLE `recommand_keywords` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `recommand_menus`
+--
+
+DROP TABLE IF EXISTS `recommand_menus`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `recommand_menus` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `store_id` bigint unsigned DEFAULT NULL,
+  `menu_id` bigint unsigned DEFAULT NULL,
+  `score` bigint DEFAULT NULL,
+  `recommand_keyword_id` bigint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_stores_recommand_menus` (`store_id`),
+  KEY `fk_recommand_keywords_recommand_menus` (`recommand_keyword_id`),
+  KEY `fk_menus_recommand_menus` (`menu_id`),
+  CONSTRAINT `fk_menus_recommand_menus` FOREIGN KEY (`menu_id`) REFERENCES `menus` (`id`),
+  CONSTRAINT `fk_recommand_keywords_recommand_menus` FOREIGN KEY (`recommand_keyword_id`) REFERENCES `recommand_keywords` (`id`),
+  CONSTRAINT `fk_stores_recommand_menus` FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `recommand_menus`
+--
+
+LOCK TABLES `recommand_menus` WRITE;
+/*!40000 ALTER TABLE `recommand_menus` DISABLE KEYS */;
+/*!40000 ALTER TABLE `recommand_menus` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `recommand_questions`
+--
+
+DROP TABLE IF EXISTS `recommand_questions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `recommand_questions` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `question` longtext,
+  `recommand_keyword_id` bigint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_recommand_keywords_recommand_questions` (`recommand_keyword_id`),
+  CONSTRAINT `fk_recommand_keywords_recommand_questions` FOREIGN KEY (`recommand_keyword_id`) REFERENCES `recommand_keywords` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `recommand_questions`
+--
+
+LOCK TABLES `recommand_questions` WRITE;
+/*!40000 ALTER TABLE `recommand_questions` DISABLE KEYS */;
+/*!40000 ALTER TABLE `recommand_questions` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `stores`
+--
+
+DROP TABLE IF EXISTS `stores`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `stores` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `store` longtext,
+  `address` longtext,
+  `user_id` longtext,
+  `password` longtext,
+  `store_number` longtext,
+  `manager` longtext,
+  `phone_number` longtext,
+  `approved` tinyint(1) DEFAULT NULL,
+  `paid` tinyint(1) DEFAULT NULL,
+  `refresh_token` longtext,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `stores`
+--
+
+LOCK TABLES `stores` WRITE;
+/*!40000 ALTER TABLE `stores` DISABLE KEYS */;
+INSERT INTO `stores` VALUES (1,'sikdorang','sikdorang','asdf','$2a$10$aTlFDHKtz6jCtKPtomhN1.kyyM6VBBgIws5UNLbqceff/kj6wT.G.','01025594304','sanghyeon','01025594304',1,1,'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzU3MTc1MzUsInN0b3JlSWQiOjF9.r7OZH_jSUcZDACIISSoCSZKBNOkEmesV_B5P-XhGlVg');
+/*!40000 ALTER TABLE `stores` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `tags`
+--
+
+DROP TABLE IF EXISTS `tags`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tags` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `tag` longtext,
+  `menu_id` bigint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_tags_menu` (`menu_id`),
+  CONSTRAINT `fk_tags_menu` FOREIGN KEY (`menu_id`) REFERENCES `menus` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `tags`
+--
+
+LOCK TABLES `tags` WRITE;
+/*!40000 ALTER TABLE `tags` DISABLE KEYS */;
+/*!40000 ALTER TABLE `tags` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2025-04-09 15:54:57


### PR DESCRIPTION
## 개요

카테고리와 메뉴 관리에 대한 API를 연동했습니다.
(영상자료는 slack에 첨부)

## 상세 내용

1. 직전의 PR(issue #47)에 대한 코멘트 수정사항을 반영했습니다.
2. Messages의 내용을 업데이트했습니다.
-  invalidPriceError: '가격은 숫자만 입력할 수 있습니다.',
-  syncMenusSuccess: '변경사항 저장에 성공했습니다.'
3. Zustand를 이용해서 parallel route로 구현한 delete modal과 메뉴 관리 페이지를 연동했습니다.
4. batch request를 이용해서 API를 요청합니다.
5. Swiper 라이브러리를 제거했습니다.
6. 변경사항 저장하기 버튼을 추가했습니다.
7. 가격에 문자값이 들어가면 예외로 처리했습니다.

## 이슈

- close #48 
