### PR TITLE
hotfix: price update error in menu table

### DIFF
--- a/apps/fe/src/app/menu/page.tsx
+++ b/apps/fe/src/app/menu/page.tsx
@@ -129,7 +129,7 @@ export default function MenuPage() {
       {
         id: -Date.now(),
         menu: '',
-        price: 0,
+        price: null,
         category: '',
         status: '판매 예정',
         order: newOrder.toString(),

--- a/apps/fe/src/components/pages/menu/MenuTableElement.tsx
+++ b/apps/fe/src/components/pages/menu/MenuTableElement.tsx
@@ -48,7 +48,7 @@ export default function MenuTableElement({
       <td className="text-center">
         <MenuTextInput
           variant="menu"
-          defaultValue={item.price.toString()}
+          defaultValue={item.price?.toString()}
           placeholder="가격"
           onSave={(value) => {
             const numericValue = Number(value);
@@ -59,15 +59,16 @@ export default function MenuTableElement({
               }));
             } else {
               setMenuErrors((prev) => {
-                const { [item.id]: rest } = prev;
+                const rest = { ...prev };
+                delete rest[item.id]; // 해당 id만 삭제
                 return rest;
               });
               updateMenuItem(item.id, 'price', numericValue);
             }
           }}
           maxLength={11}
-          className={`p-2 my-6`}
-          errorMessage={menuErrors[item.id]}
+          className="p-2 my-6"
+          errorMessage={menuErrors?.[item.id]}
         />
       </td>
 

--- a/apps/fe/src/types/model/menu.ts
+++ b/apps/fe/src/types/model/menu.ts
@@ -10,7 +10,7 @@ export interface IMenuDetailsItem {
 export interface IManageMenuItem {
   id: number;
   menu: string;
-  price: number;
+  price: number | null;
   category: string | null;
   status: string;
   order: string;


### PR DESCRIPTION
## 개요

메뉴 관리에서 메뉴 가격 수정 시 에러가 나오는 버그를 개선했습니다.

          onSave={(value) => {
            const numericValue = Number(value);
            if (isNaN(numericValue)) {
              setMenuErrors((prev) => ({
                ...prev,
                [item.id]: MESSAGES.invalidPriceError,
              }));
            } else {
              setMenuErrors((prev) => {
                const rest = { ...prev }; <-- 객체를 rest에 받음
                delete rest[item.id]; // 해당 id만 삭제 <-- 에러가 없으면 해당 에러를 가진 메뉴 id만 배열에서 제거
                return rest; <-- 객체를 return
              });
              updateMenuItem(item.id, 'price', numericValue);
            }
          }}
          
rest를 객체로 반환시켜서 문제를 해결했습니다.

## 이슈

- close #68 
