### PR TITLE
fix: fix conditions of preview and details

### DIFF
--- a/apps/be/internal/menu/dto/update_description_request.dto.go
+++ b/apps/be/internal/menu/dto/update_description_request.dto.go
@@ -1,8 +1,8 @@
 package dto
 
 type UpdateDescriptionRequestDTO struct {
-	Preview string     `json:"preview"`
-	Details string     `json:"details"`
+	Preview *string     `json:"preview"`
+	Details *string     `json:"details"`
 	Tags    []TagDTO   `json:"tags"`
 	Images  []ImageDTO `json:"images"`
 }

--- a/apps/be/internal/menu/service/menu.service.go
+++ b/apps/be/internal/menu/service/menu.service.go
@@ -213,16 +213,16 @@ func (s *menuService) UpdateDescription(storeID, menuID uint, body dto.UpdateDes
 	}
 
 	// Preview 처리
-	if body.Preview != "" {
-		menu.Preview = body.Preview
+	if body.Preview != nil {
+		menu.Preview = *body.Preview
 		if err := s.repo.UpdateMenu(&menu); err != nil {
 			execErrs = append(execErrs, err)
 		}
 	}
 
 	// Details 처리
-	if body.Details != "" {
-		menu.Details = body.Details
+	if body.Details != nil {
+		menu.Details = *body.Details
 		if err := s.repo.UpdateMenu(&menu); err != nil {
 			execErrs = append(execErrs, err)
 		}


### PR DESCRIPTION
## 개요
디테일을 업데이트할 때, 조건에 에러가 있어 수정합니다.
빈 문자열로 preview와 details가 올 경우 빈 문자열을 저장할 수 있도록 하였습니다.
## 없슈
