### PR TITLE
chore: simplify FE GitHub Actions workflow

### DIFF
--- a/.github/workflows/fe-lint-build.yml
+++ b/.github/workflows/fe-lint-build.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'apps/fe/**' # fe 디렉토리 변경 시에만 작동
-      - '.github/workflows/fe-lint-build.yml' # 이 설정 파일 수정 시에도 작동
 
 jobs:
   check-fe-changes:

--- a/.github/workflows/fe-lint-build.yml
+++ b/.github/workflows/fe-lint-build.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Get pnpm store directory
         id: pnpm-cache-dir
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm config get store-dir)" >> $GITHUB_ENV
 
       - name: Cache pnpm modules # pnpm 캐시 설정
         uses: actions/cache@v4

--- a/.github/workflows/fe-lint-build.yml
+++ b/.github/workflows/fe-lint-build.yml
@@ -44,18 +44,6 @@ jobs:
         with:
           version: 8.6.0
 
-      - name: Get pnpm store directory
-        id: pnpm-cache-dir
-        run: echo "STORE_PATH=$(pnpm config get store-dir)" >> $GITHUB_ENV
-
-      - name: Cache pnpm modules # pnpm 캐시 설정
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-${{ runner.os }}-
-
       - name: Install dependencies # 의존성 패키지 설치
         run: pnpm install -r
 

--- a/.github/workflows/fe-lint-build.yml
+++ b/.github/workflows/fe-lint-build.yml
@@ -44,10 +44,14 @@ jobs:
         with:
           version: 8.6.0
 
+      - name: Get pnpm store directory
+        id: pnpm-cache-dir
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_ENV
+
       - name: Cache pnpm modules # pnpm 캐시 설정
         uses: actions/cache@v4
         with:
-          path: ~/.pnpm-store
+          path: ${{ env.STORE_PATH }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             pnpm-store-${{ runner.os }}-


### PR DESCRIPTION
## 개요

잘못 들어간 paths 설정을 제거하고, pnpm 캐시가 제대로 동작하지 않아 우선은 해당 step을 제거했습니다. (추후에 actions 실행 시간을 줄일 수 있는 다양한 방법을 찾아보며 그 때 캐싱을 다시 적용해 보겠습니다.)

- paths 설정 제거 (apps/fe/**, .github/workflows/fe-lint-build.yml)
- pnpm 캐시 설정 (actions/cache) 제거

## 이슈

- 없음
